### PR TITLE
强行指定版本用来修复降低版本无法构建

### DIFF
--- a/.github/workflows/nuget-tag-publish.yml
+++ b/.github/workflows/nuget-tag-publish.yml
@@ -12,7 +12,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
- 
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          5.0.x
+          6.0.0
+
     - name: Install dotnet tool
       run: dotnet tool install -g dotnetCampus.TagToVersion
 


### PR DESCRIPTION
修复 CS1705 错误，内部项目不敢追新使用新版本的 .NET SDK 和 .NET Runtime 因此将会因为产品项目的构建 SDK 低于此库发布时采用的 SDK 而失败

```
CSC : error CS1705: 标识为“dotnetCampus.WindowsAPICodePack, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null”的程序集“dotnetCampus.WindowsAPICodePack”所使用的“PresentationCore, Version=6.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35”版本高于所引用的标识为“PresentationCore, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35”的程序集“PresentationCore”
```